### PR TITLE
updated hapiserver.js to v17.3.1 syntax

### DIFF
--- a/hapiserver.js
+++ b/hapiserver.js
@@ -3,18 +3,19 @@
 const Hapi = require('hapi');
 
 // Create a server with a host and port
-const server = new Hapi.Server();
-server.connection({ 
-    host: 'localhost', 
-    port: 8000 
+const server = new Hapi.Server({
+    host: 'localhost',
+    port: 8000
 });
 
 // Add the route
 server.route({
     method: 'GET',
-    path:'/', 
-    handler: function (request, reply) {
-        return reply('Hello World!').header('Connection', 'close');
+    path:'/',
+    handler: function (request, h) {
+        const response = h.response('Hello World!');
+        response.header('Connection','close');
+        return response;
     }
 });
 


### PR DESCRIPTION
The syntax for Hapi servers changed recently.  The current version of this file returns syntax errors for the latest version.  Updated version works the same as before.